### PR TITLE
standardise the start / end of emails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3439,10 +3439,21 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        }
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/templates/invitation.html
+++ b/templates/invitation.html
@@ -1,15 +1,10 @@
-<p>Hello {{name}}</p>
-
 <p>You have an invitation to join {{establishment}}.</p>
 
 <p>To accept this invitation, please follow the link below:<br />
   <a href="{{acceptLink}}">{{acceptLink}}</a>
 </p>
 
-<p>This link will stop working 7 days after you've received it.<br />
-This is to keep the service secure.</p>
-
-<p>Many thanks<br />
-Animals in Science Regulation Unit</p>
-
-<p>(This is an automated email. Please do not reply.)</p>
+<p>
+  This link will stop working 7 days after you've received it.<br />
+  This is to keep the service secure.
+</p>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -2,5 +2,14 @@
   <img src="cid:hologo" alt="Home Office" width="150" height="36" style="margin-top:10px" />
 </div>
 <div style="background-color:#f3f3f3;padding:30px 66px;">
-{{>message}}
+  <p>Hello {{name}}</p>
+
+  {{>message}}
+
+  <p>
+    Many thanks,<br />
+    Animals in Science Regulation Unit
+  </p>
+
+  <p>(This is an automated email. Please do not reply.)</p>
 </div>

--- a/templates/notification-task-action.html
+++ b/templates/notification-task-action.html
@@ -1,5 +1,3 @@
-<p>Dear {{ name }}</p>
-
 <p>There is a {{ taskType }} in your task list that needs your attention.</p>
 
 <p>{{ identifier }}: {{ identifierValue }}</p>
@@ -8,9 +6,3 @@
   You can see more details about this task by visiting
   <a href="{{ url }}">{{ url }}</a>
 </p>
-
-<p>Kind regards</p>
-
-<p>Animals in Science Regulation Unit</p>
-
-<p>(This is an automated email. Please do not reply.)</p>

--- a/templates/notification-task-change.html
+++ b/templates/notification-task-change.html
@@ -1,5 +1,3 @@
-<p>Dear {{ name }}</p>
-
 <p>The status of a {{ taskType }} has changed.</p>
 
 <p>{{ identifier }}: {{ identifierValue }}</p>
@@ -12,9 +10,3 @@
   You can see more details about this task by visiting
   <a href="{{ url }}">{{ url }}</a>
 </p>
-
-<p>Kind regards</p>
-
-<p>Animals in Science Regulation Unit</p>
-
-<p>(This is an automated email. Please do not reply.)</p>


### PR DESCRIPTION
Use the same standard language at the start and end of our emails.

Moved the common parts to the layout to avoid inconsistencies.