### PR TITLE
Add errorEvent property to config

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,5 +4,6 @@ module.exports = {
   email: {
     apiKey: process.env.EMAILER_API_KEY,
     template: process.env.EMAILER_TEMPLATE_KEY
-  }
+  },
+  errorEvent: 'asl.error'
 };


### PR DESCRIPTION
This means that errors in the service will be logged to sysdig and trigger alerts and it won't just fail silently.